### PR TITLE
Add sensors on usb bus and no-temp sensor exception

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # check_temp
-Temperature check (not only) for nagios. Performance data included.
+Temperature check for icinga7nagios. Performance data included. Thresholds used by sensors. 
 
 Uses sysfs for data retrieval, so it's not necessary to have lm_sensors installed (although recommended for sensors-detect, which helps with loading appropriate kernel modules).
 
 Dependencies
 * Python >3.4
-* NRPE
+* NRPE, check_by_ssh, local or icinga agent

--- a/check_temp.py
+++ b/check_temp.py
@@ -14,7 +14,6 @@ def main(argv):
 
     parser = argparse.ArgumentParser()
     parser.add_argument('-m', help='minimum temperature')
-    parser.add_argument('--debug', help='print debug',default=False)
     args = (parser.parse_args())
 
     if args.m:

--- a/check_temp.py
+++ b/check_temp.py
@@ -11,8 +11,10 @@ def main(argv):
     count = 0
     minTemp = "0.0"
 
+
     parser = argparse.ArgumentParser()
     parser.add_argument('-m', help='minimum temperature')
+    parser.add_argument('--debug', help='print debug',default=False)
     args = (parser.parse_args())
 
     if args.m:
@@ -41,6 +43,10 @@ def main(argv):
 
                 #Get current temperature
                 (tempStr, tempF) = getTemp(temp, temp)
+                
+                #skip zero values
+                if not tempStr:
+                    continue
 
                 #Get label if exists
                 labelP = temp.with_name(tempName + '_label')
@@ -85,7 +91,10 @@ def resolveName(curName, path):
     elif (parts[3] == "platform"):
         return parts[4]
     elif (parts[3].startswith("pci")):
-        pciAddr = parts[5].split(':', 1)
+        if 'usb' in parts[5]:
+            pciAddr = parts[5]
+        else:
+            pciAddr = parts[5].split(':', 1)
         return curName + ".pci" + pciAddr[1]
     else:
         return curName + ".TODO.unknown"
@@ -96,13 +105,18 @@ def getTemp(curPath, tempName):
     else:
         tempPath = curPath
 
+    tempString = ""
+    tempFloat = 0
     if (tempPath.exists()):
         with tempPath.open() as read:
-            tempFloat = (int(read.readline().strip())/1000)
+            try:
+                tempFloat = (int(read.readline().strip())/1000)
+            except OSError as e:
+                    #print("Sensor {} has no value {}".format(tempPath,e))
+                    return (False,float(0))
+
         tempString = "%.1f" % tempFloat
-    else:
-        tempString = ""
-        tempFloat = 0
+
     return (tempString, tempFloat)
 
 if __name__ == "__main__":


### PR DESCRIPTION
I like how simple this command is and I would like to contribute two fixes for "newer" hardware:

In my case, some devices had some sensons with a path like:
`/sys/devices/pci0000:00/0000:00:14.0/usb1/1-4/1-4:1.2/xxxxx/power_supply/hidpp_battery_0`
and some sensors had  a temp_input file but no data:
```ls -la /sys/class/hwmon/hwmon3/temp1_input
-r--r--r-- 1 root root 4096 Dec 10 12:12 /sys/class/hwmon/hwmon3/temp1_input

cat /sys/class/hwmon/hwmon3/temp1_input 
cat: /sys/class/hwmon/hwmon3/temp1_input: No data available
```

Output from a NUCi6
`OK: Average temperature is 49.0°C|'pch_skylake.2-temp1'=56.5;;;0.0; 'acpitz.0-temp1'=27.8;;105.0;0.0;105.0 'acpitz.0-temp2'=29.8;;105.0;0.0;105.0 'coretemp.0-Core 1'=56.0;100.0;100.0;0.0;100.0 'coretemp.0-Package id 0'=62.0;100.0;100.0;0.0;100.0 'coretemp.0-Core 0'=62.0;100.0;100.0;0.0;100.0`

Output from a Proliant Gen10
`OK: Average temperature is 49.1C|'tg3.pci03:00.1-temp1'=61.0;100.0;110.0;0.0;110.0 'tg3.pci03:00.2-temp1'=61.0;100.0;110.0;0.0;110.0 'coretemp.0-Core 4'=40.0;90.0;100.0;0.0;100.0 'coretemp.0-Core 1'=45.0;90.0;100.0;0.0;100.0 'coretemp.0-Core 5'=43.0;90.0;100.0;0.0;100.0 'coretemp.0-Core 2'=44.0;90.0;100.0;0.0;100.0 'coretemp.0-Core 6'=42.0;90.0;100.0;0.0;100.0 'coretemp.0-Package id 0'=47.0;90.0;100.0;0.0;100.0 'coretemp.0-Core 3'=40.0;90.0;100.0;0.0;100.0 'coretemp.0-Core 7'=39.0;90.0;100.0;0.0;100.0 'coretemp.0-Core 0'=47.0;90.0;100.0;0.0;100.0 'be2net.pci04:00.1-temp1'=45.0;;;0.0; 'acpitz.0-temp1'=8.3;;31.3;0.0;31.3 'tg3.pci03:00.3-temp1'=61.0;100.0;110.0;0.0;110.0 'tg3.pci03:00.0-temp1'=61.0;100.0;110.0;0.0;110.0 'coretemp.1-Core 4'=55.0;90.0;100.0;0.0;100.0 'coretemp.1-Core 1'=56.0;90.0;100.0;0.0;100.0 'coretemp.1-Core 5'=56.0;90.0;100.0;0.0;100.0 'coretemp.1-Core 2'=56.0;90.0;100.0;0.0;100.0 'coretemp.1-Core 6'=56.0;90.0;100.0;0.0;100.0 'coretemp.1-Package id 1'=57.0;90.0;100.0;0.0;100.0 'coretemp.1-Core 3'=54.0;90.0;100.0;0.0;100.0 'coretemp.1-Core 7'=53.0;90.0;100.0;0.0;100.0 'coretemp.1-Core 0'=55.0;90.0;100.0;0.0;100.0 'be2net.pci04:00.0-temp1'=45.0;;;0.0;`

Output from a Lenovo Carbon Gen 8 (dev system :))
```OK: Average temperature is 40.3C|'iwlwifi_1.6-temp1'=47.0;;;0.0; 'pch_cannonlake.4-temp1'=47.0;;;0.0; 'coretemp.0-Core 1'=52.0;100.0;100.0;0.0;100.0 'coretemp.0-Core 2'=46.0;100.0;100.0;0.0;100.0 'coretemp.0-Package id 0'=52.0;100.0;100.0;0.0;100.0 'coretemp.0-Core 3'=46.0;100.0;100.0;0.0;100.0 'coretemp.0-Core 0'=47.0;100.0;100.0;0.0;100.0 'thinkpad_hwmon-temp6'=48.0;;;0.0; 'thinkpad_hwmon-temp3'=39.0;;;0.0; 'thinkpad_hwmon-temp7'=48.0;;;0.0; 'thinkpad_hwmon-temp4'=0.0;;;0.0; 'thinkpad_hwmon-temp8'=0.0;;;0.0; 'thinkpad_hwmon-CPU'=48.0;;;0.0; 'thinkpad_hwmon-temp5'=42.0;;;0.0; 'nvme.pci03:00.0-Sensor 2'=37.9;65261.8;;0.0; 'nvme.pci03:00.0-Composite'=38.9;83.8;84.8;0.0;84.8 'nvme.pci03:00.0-Sensor 1'=38.9;65261.8;;0.0; 'acpitz.1-temp1'=48.0;;128.0;0.0;128.0```